### PR TITLE
Group Chat scalability changes for get methods

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import '__lib.dart';
 
 void main() async {
-  testGetGroupMemberCount();
+  testGetGroupMembers();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import '__lib.dart';
 
 void main() async {
-  testGetGroupMemberStatus();
+  testGetGroupMembersPublicKeys();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import '__lib.dart';
 
 void main() async {
-  testGetGroupMembersPublicKeys();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,7 @@
 import '__lib.dart';
-import 'test_functions/chat/get_group_info.dart';
 
 void main() async {
-  testGetGroupInfo();
+  testGetGroupMemberCount();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import '__lib.dart';
 
 void main() async {
-  testGetAllGroupMembers();
+  testGetGroupMemberStatus();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
 import '__lib.dart';
+import 'test_functions/chat/get_group_info.dart';
 
 void main() async {
+  testGetGroupInfo();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import '__lib.dart';
 
 void main() async {
-  testGetGroupMembers();
+  testGetAllGroupMembers();
   runApp(
     ProviderScope(
       child: const MyApp(),

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -21,3 +21,4 @@ export 'get_group_info.dart';
 export 'get_group_member_count.dart';
 export 'get_group_members.dart';
 export 'get_all_group_members.dart';
+export 'get_group_member_status.dart';

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -19,3 +19,4 @@ export 'send_reaction.dart';
 export 'send_reply.dart';
 export 'get_group_info.dart';
 export 'get_group_member_count.dart';
+export 'get_group_members.dart';

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -20,3 +20,4 @@ export 'send_reply.dart';
 export 'get_group_info.dart';
 export 'get_group_member_count.dart';
 export 'get_group_members.dart';
+export 'get_all_group_members.dart';

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -22,3 +22,4 @@ export 'get_group_member_count.dart';
 export 'get_group_members.dart';
 export 'get_all_group_members.dart';
 export 'get_group_member_status.dart';
+export 'get_group_members_public_keys.dart';

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -23,3 +23,4 @@ export 'get_group_members.dart';
 export 'get_all_group_members.dart';
 export 'get_group_member_status.dart';
 export 'get_group_members_public_keys.dart';
+export 'get_all_group_members_public_keys.dart';

--- a/example/lib/test_functions/chat/__chats.dart
+++ b/example/lib/test_functions/chat/__chats.dart
@@ -17,3 +17,5 @@ export 'send_file.dart';
 export 'send_composite.dart';
 export 'send_reaction.dart';
 export 'send_reply.dart';
+export 'get_group_info.dart';
+export 'get_group_member_count.dart';

--- a/example/lib/test_functions/chat/get_all_group_members.dart
+++ b/example/lib/test_functions/chat/get_all_group_members.dart
@@ -1,12 +1,13 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetAllGroupMembers() async {
+Future<void> testGetAllGroupMembers() async {
   final result = await getAllGroupMembers(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
-  for (var r in result) {
-    print(r.address);
-  }
+  print('testGetAllGroupMembers result: $result');
+
+  result.forEach((member) {
+    print('testGetAllGroupMembers member address: ${member.address}');
+  });
 }

--- a/example/lib/test_functions/chat/get_all_group_members.dart
+++ b/example/lib/test_functions/chat/get_all_group_members.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetAllGroupMembers() async {
+  final result = await getAllGroupMembers(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/example/lib/test_functions/chat/get_all_group_members_public_keys.dart
+++ b/example/lib/test_functions/chat/get_all_group_members_public_keys.dart
@@ -1,9 +1,9 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetAllGroupMembersPublicKeys() async {
+Future<void> testGetAllGroupMembersPublicKeys() async {
   final result = await getAllGroupMembersPublicKeys(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetAllGroupMembersPublicKeys result: $result');
 }

--- a/example/lib/test_functions/chat/get_all_group_members_public_keys.dart
+++ b/example/lib/test_functions/chat/get_all_group_members_public_keys.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetAllGroupMembersPublicKeys() async {
+  final result = await getAllGroupMembersPublicKeys(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/example/lib/test_functions/chat/get_group_info.dart
+++ b/example/lib/test_functions/chat/get_group_info.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetGroupInfo() async {
+  final result = await getGroupInfo(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/example/lib/test_functions/chat/get_group_info.dart
+++ b/example/lib/test_functions/chat/get_group_info.dart
@@ -1,9 +1,9 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetGroupInfo() async {
+Future<void> testGetGroupInfo() async {
   final result = await getGroupInfo(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetGroupInfo result: $result');
 }

--- a/example/lib/test_functions/chat/get_group_member_count.dart
+++ b/example/lib/test_functions/chat/get_group_member_count.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetGroupMemberCount() async {
+  final result = await getGroupMemberCount(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/example/lib/test_functions/chat/get_group_member_count.dart
+++ b/example/lib/test_functions/chat/get_group_member_count.dart
@@ -1,9 +1,9 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetGroupMemberCount() async {
+Future<void> testGetGroupMemberCount() async {
   final result = await getGroupMemberCount(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetGroupMemberCount result: $result');
 }

--- a/example/lib/test_functions/chat/get_group_member_status.dart
+++ b/example/lib/test_functions/chat/get_group_member_status.dart
@@ -1,12 +1,10 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetAllGroupMembers() async {
-  final result = await getAllGroupMembers(
+void testGetGroupMemberStatus() async {
+  final result = await getGroupMemberStatus(
+      did: '0xBF8e4e027D59B11A30096AA6a51A0B5f79C7e648',
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
   print(result);
-  for (var r in result) {
-    print(r.address);
-  }
 }

--- a/example/lib/test_functions/chat/get_group_member_status.dart
+++ b/example/lib/test_functions/chat/get_group_member_status.dart
@@ -1,10 +1,10 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetGroupMemberStatus() async {
+Future<void> testGetGroupMemberStatus() async {
   final result = await getGroupMemberStatus(
       did: '0xBF8e4e027D59B11A30096AA6a51A0B5f79C7e648',
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetGroupMemberStatus result: $result');
 }

--- a/example/lib/test_functions/chat/get_group_members.dart
+++ b/example/lib/test_functions/chat/get_group_members.dart
@@ -1,9 +1,9 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetGroupMembers() async {
+Future<void> testGetGroupMembers() async {
   final result = await getGroupMembers(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetGroupMembers result: $result');
 }

--- a/example/lib/test_functions/chat/get_group_members.dart
+++ b/example/lib/test_functions/chat/get_group_members.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetGroupMembers() async {
+  final result = await getGroupMembers(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/example/lib/test_functions/chat/get_group_members_public_keys.dart
+++ b/example/lib/test_functions/chat/get_group_members_public_keys.dart
@@ -1,9 +1,9 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
-void testGetGroupMembersPublicKeys() async {
+Future<void> testGetGroupMembersPublicKeys() async {
   final result = await getGroupMembersPublicKeys(
       chatId:
           '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
 
-  print(result);
+  print('testGetGroupMembersPublicKeys result: $result');
 }

--- a/example/lib/test_functions/chat/get_group_members_public_keys.dart
+++ b/example/lib/test_functions/chat/get_group_members_public_keys.dart
@@ -1,0 +1,9 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+void testGetGroupMembersPublicKeys() async {
+  final result = await getGroupMembersPublicKeys(
+      chatId:
+          '5ed6ac1c59384fc447986141e5ff593b8fd446d63bd3a9a0f16e06e012bc86d3');
+
+  print(result);
+}

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -7,6 +7,8 @@ export 'src/helper/user.dart';
 export 'src/helper/service.dart';
 export 'src/helper/signature.dart';
 
+export 'src/models/group_info_dto.dart';
+
 export 'src/chat.dart';
 export 'src/chats.dart';
 export 'src/requests.dart';
@@ -24,3 +26,4 @@ export 'src/add_admins.dart';
 export 'src/add_members.dart';
 export 'src/remove_admins.dart';
 export 'src/remove_members.dart';
+export 'src/get_group_info.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -10,6 +10,7 @@ export 'src/helper/signature.dart';
 export 'src/models/group_info_dto.dart';
 export 'src/models/chat_member_counts.dart';
 export 'src/models/chat_members.dart';
+export 'src/models/group_member_status.dart';
 
 export 'src/chat.dart';
 export 'src/chats.dart';
@@ -32,3 +33,4 @@ export 'src/get_group_info.dart';
 export 'src/get_group_member_count.dart';
 export 'src/get_group_members.dart';
 export 'src/get_all_group_members.dart';
+export 'src/get_group_member_status.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -36,3 +36,4 @@ export 'src/get_group_members.dart';
 export 'src/get_all_group_members.dart';
 export 'src/get_group_member_status.dart';
 export 'src/get_group_members_public_keys.dart';
+export 'src/get_all_group_members_public_keys.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -9,6 +9,7 @@ export 'src/helper/signature.dart';
 
 export 'src/models/group_info_dto.dart';
 export 'src/models/chat_member_counts.dart';
+export 'src/models/chat_members.dart';
 
 export 'src/chat.dart';
 export 'src/chats.dart';
@@ -29,3 +30,4 @@ export 'src/remove_admins.dart';
 export 'src/remove_members.dart';
 export 'src/get_group_info.dart';
 export 'src/get_group_member_count.dart';
+export 'src/get_group_members.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -11,6 +11,7 @@ export 'src/models/group_info_dto.dart';
 export 'src/models/chat_member_counts.dart';
 export 'src/models/chat_members.dart';
 export 'src/models/group_member_status.dart';
+export 'src/models/group_member_public_key.dart';
 
 export 'src/chat.dart';
 export 'src/chats.dart';
@@ -34,3 +35,4 @@ export 'src/get_group_member_count.dart';
 export 'src/get_group_members.dart';
 export 'src/get_all_group_members.dart';
 export 'src/get_group_member_status.dart';
+export 'src/get_group_members_public_keys.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -31,3 +31,4 @@ export 'src/remove_members.dart';
 export 'src/get_group_info.dart';
 export 'src/get_group_member_count.dart';
 export 'src/get_group_members.dart';
+export 'src/get_all_group_members.dart';

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -8,6 +8,7 @@ export 'src/helper/service.dart';
 export 'src/helper/signature.dart';
 
 export 'src/models/group_info_dto.dart';
+export 'src/models/chat_member_counts.dart';
 
 export 'src/chat.dart';
 export 'src/chats.dart';
@@ -27,3 +28,4 @@ export 'src/add_members.dart';
 export 'src/remove_admins.dart';
 export 'src/remove_members.dart';
 export 'src/get_group_info.dart';
+export 'src/get_group_member_count.dart';

--- a/lib/src/chat/src/get_all_group_members.dart
+++ b/lib/src/chat/src/get_all_group_members.dart
@@ -1,0 +1,29 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+Future<List<ChatMemberProfile>> getAllGroupMembers({
+  required String chatId,
+}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final count = await getGroupMemberCount(chatId: chatId);
+
+  final limit = 5000;
+
+  final totalPages = (count.overallCount / limit).ceil();
+
+  final pagesResult = await Future.wait(
+    List.generate(
+      totalPages,
+      (index) => getGroupMembers(chatId: chatId, page: index + 1, limit: limit),
+    ),
+  );
+
+  var members = <ChatMemberProfile>[];
+  for (var element in pagesResult) {
+    members.addAll(element);
+  }
+
+  return members;
+}

--- a/lib/src/chat/src/get_all_group_members_public_keys.dart
+++ b/lib/src/chat/src/get_all_group_members_public_keys.dart
@@ -1,0 +1,30 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+Future<List<GroupMemberPublicKey>> getAllGroupMembersPublicKeys({
+  required String chatId,
+}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final count = await getGroupMemberCount(chatId: chatId);
+
+  final limit = 5000;
+
+  final totalPages = (count.overallCount / limit).ceil();
+
+  final pagesResult = await Future.wait(
+    List.generate(
+      totalPages,
+      (index) => getGroupMembersPublicKeys(
+          chatId: chatId, page: index + 1, limit: limit),
+    ),
+  );
+
+  var members = <GroupMemberPublicKey>[];
+  for (var element in pagesResult) {
+    members.addAll(element);
+  }
+
+  return members;
+}

--- a/lib/src/chat/src/get_group.dart
+++ b/lib/src/chat/src/get_group.dart
@@ -7,12 +7,8 @@ Future<GroupDTO?> getGroup({required String chatId}) async {
 
   final result = await http.get(path: '/v1/chat/groups/$chatId');
 
-  if (result == null) {
-    return null;
-  }
-
-  if (result is String) {
-    throw Exception(result);
+  if (result == null || result is String) {
+    throw Exception(result ?? 'Cannot find group with $chatId');
   }
 
   return GroupDTO.fromJson(result);

--- a/lib/src/chat/src/get_group_by_name.dart
+++ b/lib/src/chat/src/get_group_by_name.dart
@@ -4,7 +4,7 @@ Future<GroupDTO?> getGroupByName({required String groupName}) async {
   log("=============================================");
   log("NOTICE: The method 'getGroupByName' will be deprecated on January 1st, 2024. Please update your code to remove this.");
   log("=============================================");
-  
+
   if (groupName.isEmpty) {
     throw Exception('Group Name cannot be null or empty');
   }

--- a/lib/src/chat/src/get_group_by_name.dart
+++ b/lib/src/chat/src/get_group_by_name.dart
@@ -1,6 +1,10 @@
 import 'package:push_restapi_dart/push_restapi_dart.dart';
 
 Future<GroupDTO?> getGroupByName({required String groupName}) async {
+  log("=============================================");
+  log("NOTICE: The method 'getGroupByName' will be deprecated on January 1st, 2024. Please update your code to remove this.");
+  log("=============================================");
+  
   if (groupName.isEmpty) {
     throw Exception('Group Name cannot be null or empty');
   }

--- a/lib/src/chat/src/get_group_info.dart
+++ b/lib/src/chat/src/get_group_info.dart
@@ -1,6 +1,6 @@
 import '../../../push_restapi_dart.dart';
 
-Future<GroupInfoDTO?> getGroupInfo({required String chatId}) async {
+Future<GroupInfoDTO> getGroupInfo({required String chatId}) async {
   if (chatId.isEmpty) {
     throw Exception('chatId cannot be null or empty');
   }
@@ -8,7 +8,8 @@ Future<GroupInfoDTO?> getGroupInfo({required String chatId}) async {
   final result = await http.get(path: '/v2/chat/groups/$chatId');
 
   if (result == null || result is String) {
-    throw Exception(result??'Cannot find group');
+    throw Exception(
+        result ?? 'Failed to retrieve group information. ChatId: $chatId');
   }
 
   return GroupInfoDTO.fromJson(result);

--- a/lib/src/chat/src/get_group_info.dart
+++ b/lib/src/chat/src/get_group_info.dart
@@ -1,0 +1,20 @@
+
+import '../../../push_restapi_dart.dart';
+
+Future<GroupInfoDTO?> getGroupInfo({required String chatId}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final result = await http.get(path: '/v2/chat/groups/$chatId');
+
+  if (result == null) {
+    return null;
+  }
+
+  if (result is String) {
+    throw Exception(result);
+  }
+
+  return GroupInfoDTO.fromJson(result);
+}

--- a/lib/src/chat/src/get_group_info.dart
+++ b/lib/src/chat/src/get_group_info.dart
@@ -1,4 +1,3 @@
-
 import '../../../push_restapi_dart.dart';
 
 Future<GroupInfoDTO?> getGroupInfo({required String chatId}) async {
@@ -8,12 +7,8 @@ Future<GroupInfoDTO?> getGroupInfo({required String chatId}) async {
 
   final result = await http.get(path: '/v2/chat/groups/$chatId');
 
-  if (result == null) {
-    return null;
-  }
-
-  if (result is String) {
-    throw Exception(result);
+  if (result == null || result is String) {
+    throw Exception(result??'Cannot find group');
   }
 
   return GroupInfoDTO.fromJson(result);

--- a/lib/src/chat/src/get_group_member_count.dart
+++ b/lib/src/chat/src/get_group_member_count.dart
@@ -1,0 +1,19 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+Future<ChatMemberCounts> getGroupMemberCount({required String chatId}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final result = await http.get(path: '/v1/chat/groups/$chatId/members/count');
+
+  if (result == null) {
+    throw Exception(result);
+  }
+
+  if (result is String) {
+    throw Exception(result);
+  }
+
+  return ChatMemberCounts.fromJson(result['totalMembersCount']);
+}

--- a/lib/src/chat/src/get_group_member_count.dart
+++ b/lib/src/chat/src/get_group_member_count.dart
@@ -7,12 +7,9 @@ Future<ChatMemberCounts> getGroupMemberCount({required String chatId}) async {
 
   final result = await http.get(path: '/v1/chat/groups/$chatId/members/count');
 
-  if (result == null) {
-    throw Exception(result);
-  }
 
-  if (result is String) {
-    throw Exception(result);
+  if (result == null || result is String) {
+    throw Exception(result??'Cannot get group count');
   }
 
   return ChatMemberCounts.fromJson(result['totalMembersCount']);

--- a/lib/src/chat/src/get_group_member_count.dart
+++ b/lib/src/chat/src/get_group_member_count.dart
@@ -7,9 +7,9 @@ Future<ChatMemberCounts> getGroupMemberCount({required String chatId}) async {
 
   final result = await http.get(path: '/v1/chat/groups/$chatId/members/count');
 
-
   if (result == null || result is String) {
-    throw Exception(result??'Cannot get group count');
+    throw Exception(
+        result ?? 'Failed to retrieve group member count. ChatId: $chatId');
   }
 
   return ChatMemberCounts.fromJson(result['totalMembersCount']);

--- a/lib/src/chat/src/get_group_member_status.dart
+++ b/lib/src/chat/src/get_group_member_status.dart
@@ -17,12 +17,8 @@ Future<GroupMemberStatus> getGroupMemberStatus({
     path: '/v1/chat/groups/$chatId/members/$user/status',
   );
 
-  if (result == null) {
-    throw Exception(result);
-  }
-
-  if (result is String) {
-    throw Exception(result);
+  if (result == null || result is String) {
+    throw Exception(result ?? 'Cannot get group satus');
   }
 
   return GroupMemberStatus.fromJson(result);

--- a/lib/src/chat/src/get_group_member_status.dart
+++ b/lib/src/chat/src/get_group_member_status.dart
@@ -18,7 +18,8 @@ Future<GroupMemberStatus> getGroupMemberStatus({
   );
 
   if (result == null || result is String) {
-    throw Exception(result ?? 'Cannot get group satus');
+    throw Exception(result ??
+        'Failed to retrieve group member status. ChatId: $chatId, User: $user');
   }
 
   return GroupMemberStatus.fromJson(result);

--- a/lib/src/chat/src/get_group_member_status.dart
+++ b/lib/src/chat/src/get_group_member_status.dart
@@ -1,0 +1,29 @@
+import '../../../push_restapi_dart.dart';
+
+Future<GroupMemberStatus> getGroupMemberStatus({
+  required String chatId,
+  required String did,
+}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+  if (did.isEmpty) {
+    throw Exception('did cannot be null or empty');
+  }
+
+  final user = await getUserDID(address: did);
+
+  final result = await http.get(
+    path: '/v1/chat/groups/$chatId/members/$user/status',
+  );
+
+  if (result == null) {
+    throw Exception(result);
+  }
+
+  if (result is String) {
+    throw Exception(result);
+  }
+
+  return GroupMemberStatus.fromJson(result);
+}

--- a/lib/src/chat/src/get_group_members.dart
+++ b/lib/src/chat/src/get_group_members.dart
@@ -10,11 +10,12 @@ Future<List<ChatMemberProfile>> getGroupMembers(
     path: '/v1/chat/groups/$chatId/members?pageNumber=$page&pageSize=$limit',
   );
 
-
-
-  if (result == null ||result is String) {
-    throw Exception(result??'Cannot get $chatId members');
+  if (result == null || result is String) {
+    throw Exception(
+        result ?? 'Failed to retrieve group members. ChatId: $chatId');
   }
 
-  return (result['members'] as List).map((e) => ChatMemberProfile.fromJson(e)).toList();
+  return (result['members'] as List)
+      .map((e) => ChatMemberProfile.fromJson(e))
+      .toList();
 }

--- a/lib/src/chat/src/get_group_members.dart
+++ b/lib/src/chat/src/get_group_members.dart
@@ -10,12 +10,10 @@ Future<List<ChatMemberProfile>> getGroupMembers(
     path: '/v1/chat/groups/$chatId/members?pageNumber=$page&pageSize=$limit',
   );
 
-  if (result == null) {
-    throw Exception(result);
-  }
 
-  if (result is String) {
-    throw Exception(result);
+
+  if (result == null ||result is String) {
+    throw Exception(result??'Cannot get $chatId members');
   }
 
   return (result['members'] as List).map((e) => ChatMemberProfile.fromJson(e)).toList();

--- a/lib/src/chat/src/get_group_members.dart
+++ b/lib/src/chat/src/get_group_members.dart
@@ -1,0 +1,22 @@
+import 'package:push_restapi_dart/push_restapi_dart.dart';
+
+Future<List<ChatMemberProfile>> getGroupMembers(
+    {required String chatId, int page = 1, int limit = 20}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final result = await http.get(
+    path: '/v1/chat/groups/$chatId/members?pageNumber=$page&pageSize=$limit',
+  );
+
+  if (result == null) {
+    throw Exception(result);
+  }
+
+  if (result is String) {
+    throw Exception(result);
+  }
+
+  return (result['members'] as List).map((e) => ChatMemberProfile.fromJson(e)).toList();
+}

--- a/lib/src/chat/src/get_group_members_public_keys.dart
+++ b/lib/src/chat/src/get_group_members_public_keys.dart
@@ -1,0 +1,25 @@
+import '../../../push_restapi_dart.dart';
+
+Future<List<GroupMemberPublicKey>> getGroupMembersPublicKeys({
+  required String chatId,
+  int page = 1,
+  int limit = 20,
+}) async {
+  if (chatId.isEmpty) {
+    throw Exception('chatId cannot be null or empty');
+  }
+
+  final result = await http.get(
+      path:
+          '/v1/chat/groups/$chatId/members/publicKeys?pageNumber=$page&pageSize=$limit');
+
+  if (result == null) {
+    throw Exception(result);
+  }
+
+  if (result is String) {
+    throw Exception(result);
+  }
+
+  return (result['members'] as List).map((e) => GroupMemberPublicKey.fromJson(e)).toList();
+}

--- a/lib/src/chat/src/get_group_members_public_keys.dart
+++ b/lib/src/chat/src/get_group_members_public_keys.dart
@@ -14,7 +14,8 @@ Future<List<GroupMemberPublicKey>> getGroupMembersPublicKeys({
           '/v1/chat/groups/$chatId/members/publicKeys?pageNumber=$page&pageSize=$limit');
 
   if (result == null || result is String) {
-    throw Exception(result ?? 'Cannot get public keys for $chatId');
+    throw Exception(result ??
+        'Failed to retrieve public keys for group members. ChatId: $chatId');
   }
 
   return (result['members'] as List)

--- a/lib/src/chat/src/get_group_members_public_keys.dart
+++ b/lib/src/chat/src/get_group_members_public_keys.dart
@@ -13,13 +13,11 @@ Future<List<GroupMemberPublicKey>> getGroupMembersPublicKeys({
       path:
           '/v1/chat/groups/$chatId/members/publicKeys?pageNumber=$page&pageSize=$limit');
 
-  if (result == null) {
-    throw Exception(result);
+  if (result == null || result is String) {
+    throw Exception(result ?? 'Cannot get public keys for $chatId');
   }
 
-  if (result is String) {
-    throw Exception(result);
-  }
-
-  return (result['members'] as List).map((e) => GroupMemberPublicKey.fromJson(e)).toList();
+  return (result['members'] as List)
+      .map((e) => GroupMemberPublicKey.fromJson(e))
+      .toList();
 }

--- a/lib/src/chat/src/models/chat_member_counts.dart
+++ b/lib/src/chat/src/models/chat_member_counts.dart
@@ -1,0 +1,35 @@
+class ChatMemberCounts {
+  int overallCount;
+  int adminsCount;
+  int membersCount;
+  int pendingCount;
+  int approvedCount;
+
+  ChatMemberCounts({
+    required this.overallCount,
+    required this.adminsCount,
+    required this.membersCount,
+    required this.pendingCount,
+    required this.approvedCount,
+  });
+
+  factory ChatMemberCounts.fromJson(Map<String, dynamic> json) {
+    return ChatMemberCounts(
+      overallCount: json['overallCount'],
+      adminsCount: json['adminsCount'],
+      membersCount: json['membersCount'],
+      pendingCount: json['pendingCount'],
+      approvedCount: json['approvedCount'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'overallCount': overallCount,
+      'adminsCount': adminsCount,
+      'membersCount': membersCount,
+      'pendingCount': pendingCount,
+      'approvedCount': approvedCount,
+    };
+  }
+}

--- a/lib/src/chat/src/models/chat_members.dart
+++ b/lib/src/chat/src/models/chat_members.dart
@@ -1,0 +1,85 @@
+import '../../../../push_restapi_dart.dart';
+
+class ChatMemberProfile {
+  String address;
+  bool intent;
+  String role;
+  UserV2 userInfo;
+
+  ChatMemberProfile({
+    required this.address,
+    required this.intent,
+    required this.role,
+    required this.userInfo,
+  });
+
+  factory ChatMemberProfile.fromJson(Map<String, dynamic> json) {
+    return ChatMemberProfile(
+      address: json['address'],
+      intent: json['intent'],
+      role: json['role'],
+      userInfo: UserV2.fromJson(json['userInfo']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'address': address,
+      'intent': intent,
+      'role': role,
+      'userInfo': userInfo.toJson(),
+    };
+  }
+}
+
+class UserV2 {
+  int msgSent;
+  int maxMsgPersisted;
+  String did;
+  String wallets;
+  UserProfile profile;
+  String? encryptedPrivateKey;
+  String? publicKey;
+  String? verificationProof;
+  String? origin;
+
+  UserV2({
+    required this.msgSent,
+    required this.maxMsgPersisted,
+    required this.did,
+    required this.wallets,
+    required this.profile,
+    this.encryptedPrivateKey,
+    this.publicKey,
+    this.verificationProof,
+    this.origin,
+  });
+
+  factory UserV2.fromJson(Map<String, dynamic> json) {
+    return UserV2(
+      msgSent: json['msgSent'],
+      maxMsgPersisted: json['maxMsgPersisted'],
+      did: json['did'],
+      wallets: json['wallets'],
+      profile: UserProfile.fromJson(json['profile']),
+      encryptedPrivateKey: json['encryptedPrivateKey'],
+      publicKey: json['publicKey'],
+      verificationProof: json['verificationProof'],
+      origin: json['origin'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'msgSent': msgSent,
+      'maxMsgPersisted': maxMsgPersisted,
+      'did': did,
+      'wallets': wallets,
+      'profile': profile.toJson(),
+      'encryptedPrivateKey': encryptedPrivateKey,
+      'publicKey': publicKey,
+      'verificationProof': verificationProof,
+      'origin': origin,
+    };
+  }
+}

--- a/lib/src/chat/src/models/group_info_dto.dart
+++ b/lib/src/chat/src/models/group_info_dto.dart
@@ -1,0 +1,78 @@
+import '../../../../push_restapi_dart.dart';
+
+class GroupInfoDTO {
+  String groupName;
+  String? groupImage;
+  String groupDescription;
+  bool isPublic;
+  String groupCreator;
+  String chatId;
+  DateTime? scheduleAt;
+  DateTime? scheduleEnd;
+  String? groupType;
+  ChatStatus? status;
+  dynamic rules;
+  String? meta;
+  String? sessionKey;
+  String? encryptedSecret;
+
+  GroupInfoDTO({
+    required this.groupName,
+    this.groupImage,
+    required this.groupDescription,
+    required this.isPublic,
+    required this.groupCreator,
+    required this.chatId,
+    this.scheduleAt,
+    this.scheduleEnd,
+    this.groupType,
+    this.status,
+    this.rules,
+    this.meta,
+    this.sessionKey,
+    this.encryptedSecret,
+  });
+
+  factory GroupInfoDTO.fromJson(Map<String, dynamic> json) {
+    return GroupInfoDTO(
+      groupName: json['groupName'],
+      groupImage: json['groupImage'],
+      groupDescription: json['groupDescription'],
+      isPublic: json['isPublic'],
+      groupCreator: json['groupCreator'],
+      chatId: json['chatId'],
+      scheduleAt: json['scheduleAt'] != null
+          ? DateTime.parse(json['scheduleAt'])
+          : null,
+      scheduleEnd: json['scheduleEnd'] != null
+          ? DateTime.parse(json['scheduleEnd'])
+          : null,
+      groupType: json['groupType'],
+      status:
+          json['status'] != null ? chatStatusFromString(json['status']) : null,
+      rules: json['rules'],
+      meta: json['meta'],
+      sessionKey: json['sessionKey'],
+      encryptedSecret: json['encryptedSecret'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'groupName': groupName,
+      'groupImage': groupImage,
+      'groupDescription': groupDescription,
+      'isPublic': isPublic,
+      'groupCreator': groupCreator,
+      'chatId': chatId,
+      'scheduleAt': scheduleAt?.toIso8601String(),
+      'scheduleEnd': scheduleEnd?.toIso8601String(),
+      'groupType': groupType,
+      'status': chatStringFromChatStatus(status),
+      'rules': rules?.toJson(),
+      'meta': meta,
+      'sessionKey': sessionKey,
+      'encryptedSecret': encryptedSecret,
+    };
+  }
+}

--- a/lib/src/chat/src/models/group_member_public_key.dart
+++ b/lib/src/chat/src/models/group_member_public_key.dart
@@ -1,0 +1,23 @@
+class GroupMemberPublicKey {
+  String did;
+  String publicKey;
+
+  GroupMemberPublicKey({
+    required this.did,
+    required this.publicKey,
+  });
+
+  factory GroupMemberPublicKey.fromJson(Map<String, dynamic> json) {
+    return GroupMemberPublicKey(
+      did: json['did'],
+      publicKey: json['publicKey'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'did': did,
+      'publicKey': publicKey,
+    };
+  }
+}

--- a/lib/src/chat/src/models/group_member_status.dart
+++ b/lib/src/chat/src/models/group_member_status.dart
@@ -1,0 +1,27 @@
+class GroupMemberStatus {
+  bool isMember;
+  bool isPending;
+  bool isAdmin;
+
+  GroupMemberStatus({
+    required this.isMember,
+    required this.isPending,
+    required this.isAdmin,
+  });
+
+  factory GroupMemberStatus.fromJson(Map<String, dynamic> json) {
+    return GroupMemberStatus(
+      isMember: json['isMember'],
+      isPending: json['isPending'],
+      isAdmin: json['isAdmin'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'isMember': isMember,
+      'isPending': isPending,
+      'isAdmin': isAdmin,
+    };
+  }
+}

--- a/lib/src/models/src/user_model.dart
+++ b/lib/src/models/src/user_model.dart
@@ -108,21 +108,34 @@ class UserProfile {
   String? name;
   String? desc;
   String? picture;
+  List<String>? blockedUsersList;
   String? profileVerificationProof;
 
-  UserProfile.fromJson(Map<String, dynamic> json) {
-    name = json['name'];
-    desc = json['desc'];
-    picture = json['picture'];
-    profileVerificationProof = json['profileVerificationProof'];
+  UserProfile({
+    this.name,
+    this.desc,
+    this.picture,
+    this.blockedUsersList,
+    this.profileVerificationProof,
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      name: json['name'],
+      desc: json['desc'],
+      picture: json['picture'],
+      blockedUsersList: List<String>.from(json['blockedUsersList'] ?? []),
+      profileVerificationProof: json['profileVerificationProof'],
+    );
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = <String, dynamic>{};
-    data['name'] = name;
-    data['desc'] = desc;
-    data['picture'] = picture;
-    data['profileVerificationProof'] = profileVerificationProof;
-    return data;
+    return {
+      'name': name,
+      'desc': desc,
+      'picture': picture,
+      'blockedUsersList': blockedUsersList,
+      'profileVerificationProof': profileVerificationProof,
+    };
   }
 }


### PR DESCRIPTION
The following functions were added the sdk: 

- getGroupInfo
- getGroupByName
- getGroupMemberCount
- getGroupMembers
- getAllGroupMembers
- getGroupMembersPublicKeys
-  getAllGroupMembersPublicKeys
-  getGroupMemberStatus

Notion card: https://www.notion.so/pushprotocol/Scalability-Changes-1-Add-the-new-get-methods-for-chat-714b2e10c5af4fce96a141e14cd733a9?pvs=4